### PR TITLE
Corrected syntax for markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@ Speech to Text for Golang. Capable of continuous speech. Also wrappers for vario
 
 package nicolaifsf/go-speak imported as speech implements continuous speech recognition and offers wrappers for Google Speech, Wit.ai, IBM Speech to text, and AT&T Speech to Text apis.
 
-##Usage
+## Usage
 
-###Basic Usage
+### Basic Usage
 ```go
 import("github.com/nicolaifsf/go-speak")
 //example
 speech.GetWitKey() //note that this package is imported as speech
 ```
 
-###Wit.AI
-######Converting a sound file to text using wit.ai
+### Wit.AI
+###### Converting a sound file to text using wit.ai
 ```go
 func main(){
   speech.SetWitKey("/**Your Wit API Key here**/") //Wit API Key MUST be set before calling any other Wit.AI functions
@@ -21,7 +21,7 @@ func main(){
 }
 ```
 
-###Continuous Speech Recognition
+### Continuous Speech Recognition
 ```go
 func main(){
   speech.SetWitKey("/**Your Wit API Key here**/") //Currently ContinuousRecognition() uses wit.ai for speech recognition
@@ -29,4 +29,4 @@ func main(){
 }
 ```
 ContinuousRecognition() currently simply prints out the json response from wit.ai call
-##Installation
+## Installation


### PR DESCRIPTION
Markdown syntax corrected for few words for their proper rendering.